### PR TITLE
Implement new field in `skb->tfw_cb`

### DIFF
--- a/include/linux/skbuff.h
+++ b/include/linux/skbuff.h
@@ -884,10 +884,11 @@ struct sk_buff {
 				 */
 				unsigned long		dev_scratch;
 #ifdef CONFIG_SECURITY_TEMPESTA
-                                struct {
-                                        __u8    present : 1;
-                                        __u8    tls_type : 7;
-                                } tfw_cb;
+				struct {
+					__u16	present : 1;
+					__u16	in_socket_write_queue : 1;
+					__u16	tls_type : 7;
+				} tfw_cb;
 #endif
 			};
 		};
@@ -1132,6 +1133,7 @@ struct sk_buff {
 #define SKB_ALLOC_NAPI		0x04
 
 #ifdef CONFIG_SECURITY_TEMPESTA
+
 static inline unsigned long
 skb_tfw_is_present(struct sk_buff *skb)
 {
@@ -1150,6 +1152,19 @@ static inline unsigned char
 skb_tfw_tls_type(struct sk_buff *skb)
 {
 	return skb->tfw_cb.present ? skb->tfw_cb.tls_type : 0;
+}
+
+static inline void
+skb_tfw_set_in_socket_write_queue(struct sk_buff *skb)
+{
+	skb->tfw_cb.present = 1;
+	skb->tfw_cb.in_socket_write_queue = 1;
+}
+
+static inline bool
+skb_tfw_is_in_socket_write_queue(struct sk_buff *skb)
+{
+	return skb->tfw_cb.present ? skb->tfw_cb.in_socket_write_queue : false;
 }
 
 static inline void
@@ -3879,7 +3894,7 @@ static inline int skb_add_data(struct sk_buff *skb,
 	if (skb->ip_summed == CHECKSUM_NONE) {
 		__wsum csum = 0;
 		if (csum_and_copy_from_iter_full(skb_put(skb, copy), copy,
-					         &csum, from)) {
+						 &csum, from)) {
 			skb->csum = csum_block_add(skb->csum, csum, off);
 			return 0;
 		}


### PR DESCRIPTION
Implement new field in `skb->tfw_cb`, which is set before skb pushed to socket write queue, to check
when we can't use `skb->cb`, because it is used by kernel.