### PR TITLE
Add new field to `tempesta_socket`.

### DIFF
--- a/include/linux/tempesta.h
+++ b/include/linux/tempesta.h
@@ -39,6 +39,7 @@ typedef struct {
 
 struct socket_tempesta {
 	void	*class_prvt;
+	u16	training_epoch;
 };
 
 extern struct lsm_blob_sizes tempesta_blob_sizes;


### PR DESCRIPTION
Add per-socket training_epoch field to track the training generation for connection-related statistics. This allows associating socket events with a specific training period and prevents mixing measurements across training epochs when switching between TRAINING and DEFENCE modes.