### PR TITLE
Reuse native TCP keepalive timer as Tempesta client idle timeout mech…

### DIFF
--- a/include/net/sock.h
+++ b/include/net/sock.h
@@ -979,6 +979,8 @@ enum sock_flags {
 	SOCK_RCVMARK, /* Receive SO_MARK  ancillary data with packet */
 #ifdef CONFIG_SECURITY_TEMPESTA
 	SOCK_TEMPESTA, /* The socket is managed by Tempesta FW */
+	SOCK_TEMPESTA_CLNT, /* The socket is client Tempesta FW socket. */
+	SOCK_TEMPESTA_SRV, /* The socket is server Tempesta FW socket. */
 	SOCK_TEMPESTA_HAS_DATA, /* The socket has data in Tempesta FW
 				 * write queue.
 				 */
@@ -2935,6 +2937,9 @@ int sock_set_timestamping(struct sock *sk, int optname,
 
 void sock_enable_timestamps(struct sock *sk);
 void sock_no_linger(struct sock *sk);
+#ifdef CONFIG_SECURITY_TEMPESTA
+void sock_set_keepalive_locked(struct sock *sk);
+#endif
 void sock_set_keepalive(struct sock *sk);
 void sock_set_priority(struct sock *sk, u32 priority);
 void sock_set_rcvbuf(struct sock *sk, int val);

--- a/net/core/sock.c
+++ b/net/core/sock.c
@@ -946,6 +946,16 @@ int sock_set_timestamping(struct sock *sk, int optname,
 	return 0;
 }
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+void sock_set_keepalive_locked(struct sock *sk)
+{
+	if (sk->sk_prot->keepalive)
+		sk->sk_prot->keepalive(sk, true);
+	sock_valbool_flag(sk, SOCK_KEEPOPEN, true);
+}
+EXPORT_SYMBOL(sock_set_keepalive_locked);
+#endif
+
 void sock_set_keepalive(struct sock *sk)
 {
 	lock_sock(sk);

--- a/net/ipv4/tcp.c
+++ b/net/ipv4/tcp.c
@@ -3686,6 +3686,9 @@ int tcp_sock_set_keepidle_locked(struct sock *sk, int val)
 
 	return 0;
 }
+#ifdef CONFIG_SECURITY_TEMPESTA
+EXPORT_SYMBOL(tcp_sock_set_keepidle_locked);
+#endif
 
 int tcp_sock_set_keepidle(struct sock *sk, int val)
 {

--- a/net/ipv4/tcp_timer.c
+++ b/net/ipv4/tcp_timer.c
@@ -799,6 +799,10 @@ static void tcp_keepalive_timer (struct timer_list *t)
 	if (elapsed >= keepalive_time_when(tp)) {
 		u32 user_timeout = READ_ONCE(icsk->icsk_user_timeout);
 
+#ifdef CONFIG_SECURITY_TEMPESTA
+		if (sock_flag(sk, SOCK_TEMPESTA_CLNT))
+			goto reset;
+#endif
 		/* If the TCP_USER_TIMEOUT option is enabled, use that
 		 * to determine when to timeout instead.
 		 */
@@ -807,6 +811,9 @@ static void tcp_keepalive_timer (struct timer_list *t)
 		    icsk->icsk_probes_out > 0) ||
 		    (user_timeout == 0 &&
 		    icsk->icsk_probes_out >= keepalive_probes(tp))) {
+#ifdef CONFIG_SECURITY_TEMPESTA
+reset:
+#endif
 			tcp_send_active_reset(sk, GFP_ATOMIC,
 					      SK_RST_REASON_TCP_KEEPALIVE_TIMEOUT);
 			tcp_write_err(sk);


### PR DESCRIPTION
…anism

Replace Tempesta-specific keepalive timer with kernel TCP keepalive infrastructure (sk->sk_timer / tcp_keepalive_timer) to implement deterministic idle timeout for client connections.

Introduce SOCK_TEMPESTA_CLNT flag to identify Tempesta-managed sockets and bypass standard TCP keepalive probe escalation, converting the keepalive timer into a hard idle timeout mechanism (idle → immediate reset) for these sockets.

Expose tcp_sock_set_keepidle_locked() and sock_set_keepalive_locked() to allow Tempesta to configure keepalive parameters and enable SO_KEEPALIVE from kernel context.